### PR TITLE
Add version route prefix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ app.use(cors());
 const router = new express.Router();
 
 require('./routes/leaderboard')(router);
-app.use('/api', router);
+app.use('/v1', router);
 
 app.listen(port);
 console.log(`Started server on port ${port}!`);


### PR DESCRIPTION
We hope to improve the API over time. The changes won't always be backward compatible, so we're going to use versioning. This first iteration will have URIs prefixed with `https://devvit-api.herokuapp.com/v1/`.